### PR TITLE
x1: fix ocotp access in imx_thermal

### DIFF
--- a/arch/arm/boot/dts/imx7d.dtsi
+++ b/arch/arm/boot/dts/imx7d.dtsi
@@ -239,13 +239,21 @@
 		reg = <0x30350000 0x10000>;
 		clocks = <&clks IMX7D_OCOTP_CLK>;
 		status = "okay";
+		tempmon_calib: calib@3c {
+			reg = <0x3c 4>;
+		};
+
+		tempmon_temp_grade: temp-grade@10 {
+			reg = <0x10 4>;
+		};
 	};
 
 	tempmon: tempmon {
 		compatible = "fsl,imx7d-tempmon";
 		interrupts = <GIC_SPI 49 IRQ_TYPE_LEVEL_HIGH>;
 		fsl,tempmon =<&anatop>;
-		fsl,tempmon-data = <&ocotp>;
+		nvmem-cells = <&tempmon_calib>, <&tempmon_temp_grade>;
+		nvmem-cell-names = "calib", "temp_grade";
 		clocks = <&clks IMX7D_PLL_SYS_MAIN_CLK>;
 	};
 

--- a/drivers/nvmem/core.c
+++ b/drivers/nvmem/core.c
@@ -268,7 +268,7 @@ static int of_nvmem_match(struct device *dev, void *nvmem_np)
 	return dev->of_node == nvmem_np;
 }
 
-static struct nvmem_device *of_nvmem_find(struct device_node *nvmem_np)
+struct nvmem_device *of_nvmem_find(struct device_node *nvmem_np)
 {
 	struct device *d;
 
@@ -282,6 +282,7 @@ static struct nvmem_device *of_nvmem_find(struct device_node *nvmem_np)
 
 	return to_nvmem_device(d);
 }
+EXPORT_SYMBOL_GPL(of_nvmem_find);
 
 static struct nvmem_cell *nvmem_find_cell(const char *cell_id)
 {

--- a/drivers/nvmem/core.c
+++ b/drivers/nvmem/core.c
@@ -1100,16 +1100,8 @@ int nvmem_cell_write(struct nvmem_cell *cell, void *buf, size_t len)
 }
 EXPORT_SYMBOL_GPL(nvmem_cell_write);
 
-/**
- * nvmem_cell_read_u16() - Read a cell value as an u16
- *
- * @dev: Device that requests the nvmem cell.
- * @cell_id: Name of nvmem cell to read.
- * @val: pointer to output value.
- *
- * Return: 0 on success or negative errno.
- */
-int nvmem_cell_read_u16(struct device *dev, const char *cell_id, u16 *val)
+static int nvmem_cell_read_common(struct device *dev, const char *cell_id,
+				  void *val, size_t count)
 {
 	struct nvmem_cell *cell;
 	void *buf;
@@ -1124,16 +1116,30 @@ int nvmem_cell_read_u16(struct device *dev, const char *cell_id, u16 *val)
 		nvmem_cell_put(cell);
 		return PTR_ERR(buf);
 	}
-	if (len != sizeof(*val)) {
+	if (len != count) {
 		kfree(buf);
 		nvmem_cell_put(cell);
 		return -EINVAL;
 	}
-	memcpy(val, buf, sizeof(*val));
+	memcpy(val, buf, count);
 	kfree(buf);
 	nvmem_cell_put(cell);
 
 	return 0;
+}
+
+/**
+ * nvmem_cell_read_u16() - Read a cell value as an u16
+ *
+ * @dev: Device that requests the nvmem cell.
+ * @cell_id: Name of nvmem cell to read.
+ * @val: pointer to output value.
+ *
+ * Return: 0 on success or negative errno.
+ */
+int nvmem_cell_read_u16(struct device *dev, const char *cell_id, u16 *val)
+{
+	return nvmem_cell_read_common(dev, cell_id, val, sizeof(*val));
 }
 EXPORT_SYMBOL_GPL(nvmem_cell_read_u16);
 
@@ -1148,29 +1154,7 @@ EXPORT_SYMBOL_GPL(nvmem_cell_read_u16);
  */
 int nvmem_cell_read_u32(struct device *dev, const char *cell_id, u32 *val)
 {
-	struct nvmem_cell *cell;
-	void *buf;
-	size_t len;
-
-	cell = nvmem_cell_get(dev, cell_id);
-	if (IS_ERR(cell))
-		return PTR_ERR(cell);
-
-	buf = nvmem_cell_read(cell, &len);
-	if (IS_ERR(buf)) {
-		nvmem_cell_put(cell);
-		return PTR_ERR(buf);
-	}
-	if (len != sizeof(*val)) {
-		kfree(buf);
-		nvmem_cell_put(cell);
-		return -EINVAL;
-	}
-	memcpy(val, buf, sizeof(*val));
-
-	kfree(buf);
-	nvmem_cell_put(cell);
-	return 0;
+	return nvmem_cell_read_common(dev, cell_id, val, sizeof(*val));
 }
 EXPORT_SYMBOL_GPL(nvmem_cell_read_u32);
 

--- a/drivers/nvmem/core.c
+++ b/drivers/nvmem/core.c
@@ -1101,6 +1101,43 @@ int nvmem_cell_write(struct nvmem_cell *cell, void *buf, size_t len)
 EXPORT_SYMBOL_GPL(nvmem_cell_write);
 
 /**
+ * nvmem_cell_read_u32() - Read a cell value as an u32
+ *
+ * @dev: Device that requests the nvmem cell.
+ * @cell_id: Name of nvmem cell to read.
+ * @val: pointer to output value.
+ *
+ * Return: 0 on success or negative errno.
+ */
+int nvmem_cell_read_u32(struct device *dev, const char *cell_id, u32 *val)
+{
+	struct nvmem_cell *cell;
+	void *buf;
+	size_t len;
+
+	cell = nvmem_cell_get(dev, cell_id);
+	if (IS_ERR(cell))
+		return PTR_ERR(cell);
+
+	buf = nvmem_cell_read(cell, &len);
+	if (IS_ERR(buf)) {
+		nvmem_cell_put(cell);
+		return PTR_ERR(buf);
+	}
+	if (len != sizeof(*val)) {
+		kfree(buf);
+		nvmem_cell_put(cell);
+		return -EINVAL;
+	}
+	memcpy(val, buf, sizeof(*val));
+
+	kfree(buf);
+	nvmem_cell_put(cell);
+	return 0;
+}
+EXPORT_SYMBOL_GPL(nvmem_cell_read_u32);
+
+/**
  * nvmem_device_cell_read() - Read a given nvmem device and cell
  *
  * @nvmem: nvmem device to read from.

--- a/drivers/nvmem/core.c
+++ b/drivers/nvmem/core.c
@@ -1101,6 +1101,43 @@ int nvmem_cell_write(struct nvmem_cell *cell, void *buf, size_t len)
 EXPORT_SYMBOL_GPL(nvmem_cell_write);
 
 /**
+ * nvmem_cell_read_u16() - Read a cell value as an u16
+ *
+ * @dev: Device that requests the nvmem cell.
+ * @cell_id: Name of nvmem cell to read.
+ * @val: pointer to output value.
+ *
+ * Return: 0 on success or negative errno.
+ */
+int nvmem_cell_read_u16(struct device *dev, const char *cell_id, u16 *val)
+{
+	struct nvmem_cell *cell;
+	void *buf;
+	size_t len;
+
+	cell = nvmem_cell_get(dev, cell_id);
+	if (IS_ERR(cell))
+		return PTR_ERR(cell);
+
+	buf = nvmem_cell_read(cell, &len);
+	if (IS_ERR(buf)) {
+		nvmem_cell_put(cell);
+		return PTR_ERR(buf);
+	}
+	if (len != sizeof(*val)) {
+		kfree(buf);
+		nvmem_cell_put(cell);
+		return -EINVAL;
+	}
+	memcpy(val, buf, sizeof(*val));
+	kfree(buf);
+	nvmem_cell_put(cell);
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(nvmem_cell_read_u16);
+
+/**
  * nvmem_cell_read_u32() - Read a cell value as an u32
  *
  * @dev: Device that requests the nvmem cell.

--- a/drivers/nvmem/imx-ocotp.c
+++ b/drivers/nvmem/imx-ocotp.c
@@ -108,6 +108,7 @@ static const struct of_device_id imx_ocotp_dt_ids[] = {
 	{ .compatible = "fsl,imx6q-ocotp",  (void *)128 },
 	{ .compatible = "fsl,imx6sl-ocotp", (void *)64 },
 	{ .compatible = "fsl,imx6sx-ocotp", (void *)128 },
+	{ .compatible = "fsl,imx7d-ocotp", (void *)64 },
 	{ },
 };
 MODULE_DEVICE_TABLE(of, imx_ocotp_dt_ids);

--- a/drivers/nvmem/imx-ocotp.c
+++ b/drivers/nvmem/imx-ocotp.c
@@ -133,6 +133,10 @@ static int imx_ocotp_probe(struct platform_device *pdev)
 	if (IS_ERR(priv->clk))
 		return PTR_ERR(priv->clk);
 
+	clk_prepare_enable(priv->clk);
+	imx_ocotp_clr_err_if_set(priv->base);
+	clk_disable_unprepare(priv->clk);
+
 	of_id = of_match_device(imx_ocotp_dt_ids, dev);
 	priv->nregs = (unsigned long)of_id->data;
 	imx_ocotp_nvmem_config.size = 4 * priv->nregs;

--- a/drivers/thermal/imx_thermal.c
+++ b/drivers/thermal/imx_thermal.c
@@ -26,6 +26,7 @@
 #include <linux/slab.h>
 #include <linux/thermal.h>
 #include <linux/types.h>
+#include <linux/nvmem-consumer.h>
 
 #define REG_SET		0x4
 #define REG_CLR		0x8
@@ -222,7 +223,7 @@ struct imx_thermal_data {
 	struct thermal_cooling_device *cdev[2];
 	enum thermal_device_mode mode;
 	struct regmap *tempmon;
-	u32 c1, c2; /* See formula in imx_get_sensor_data() */
+	u32 c1, c2; /* See formula in imx_init_calib() */
 	int temp_passive;
 	int temp_critical;
 	int temp_max;
@@ -342,7 +343,7 @@ static int imx_get_temp(struct thermal_zone_device *tz, int *temp)
 	}
 
 	n_meas = (val & soc_data->temp_value_mask) >> soc_data->temp_value_shift;
-	/* See imx_get_sensor_data() for formula derivation */
+	/* See imx_init_calib() for formula derivation */
 	*temp = data->c2 - n_meas * data->c1;
 	if (data->socdata->version == TEMPMON_IMX7)
 		*temp = 25 * 1000 + 870 * (n_meas - data->c1);
@@ -539,10 +540,11 @@ static struct thermal_zone_device_ops imx_tz_ops = {
 	.get_trend = imx_get_trend,
 };
 
-static inline void imx6_calibrate_data(struct imx_thermal_data *data, u32 val)
+static void imx6_calibrate_data(struct imx_thermal_data *data, u32 val)
 {
 	int t1, t2, n1, n2;
 	u64 temp64;
+
 	/*
 	 * Sensor data layout:
 	 *   [31:20] - sensor value @ 25C
@@ -591,30 +593,9 @@ static inline void imx7_calibrate_data(struct imx_thermal_data *data, u32 val)
 	data->c1 = (val >> 9) & 0x1ff;
 }
 
-static int imx_get_sensor_data(struct platform_device *pdev)
+static int imx_init_calib(struct platform_device *pdev, u32 val)
 {
 	struct imx_thermal_data *data = platform_get_drvdata(pdev);
-	struct regmap *map;
-	int ret;
-	u32 val;
-
-	map = syscon_regmap_lookup_by_phandle(pdev->dev.of_node,
-					      "fsl,tempmon-data");
-	if (IS_ERR(map)) {
-		ret = PTR_ERR(map);
-		dev_err(&pdev->dev, "failed to get sensor regmap: %d\n", ret);
-		return ret;
-	}
-
-	if (data->socdata->version == TEMPMON_IMX7)
-		ret = regmap_read(map, IMX7_OCOTP_ANA1, &val);
-	else
-		ret = regmap_read(map, IMX6_OCOTP_ANA1, &val);
-
-	if (ret) {
-		dev_err(&pdev->dev, "failed to read sensor data: %d\n", ret);
-		return ret;
-	}
 
 	if (val == 0 || val == ~0) {
 		dev_err(&pdev->dev, "invalid sensor calibration data\n");
@@ -626,16 +607,12 @@ static int imx_get_sensor_data(struct platform_device *pdev)
 	else
 		imx6_calibrate_data(data, val);
 
-	/* use OTP for thermal grade */
-	if (data->socdata->version == TEMPMON_IMX7)
-		ret = regmap_read(map, IMX7_OCOTP_TESTER3, &val);
-	else
-		ret = regmap_read(map, OCOTP_MEM0, &val);
+	return 0;
+}
 
-	if (ret) {
-		dev_err(&pdev->dev, "failed to read temp grade: %d\n", ret);
-		return ret;
-	}
+static void imx_init_temp_grade(struct platform_device *pdev, u32 val)
+{
+	struct imx_thermal_data *data = platform_get_drvdata(pdev);
 
 	/* The maximum die temp is specified by the Temperature Grade */
 	switch ((val >> 6) & 0x3) {
@@ -663,6 +640,64 @@ static int imx_get_sensor_data(struct platform_device *pdev)
 	 */
 	data->temp_critical = data->temp_max - (1000 * 5);
 	data->temp_passive = data->temp_max - (1000 * 10);
+}
+
+static int imx_init_from_tempmon_data(struct platform_device *pdev)
+{
+	struct imx_thermal_data *data = platform_get_drvdata(pdev);
+	struct regmap *map;
+	int ret;
+	u32 val;
+
+	map = syscon_regmap_lookup_by_phandle(pdev->dev.of_node,
+					      "fsl,tempmon-data");
+	if (IS_ERR(map)) {
+		ret = PTR_ERR(map);
+		dev_err(&pdev->dev, "failed to get sensor regmap: %d\n", ret);
+		return ret;
+	}
+
+	if (data->socdata->version == TEMPMON_IMX7)
+		ret = regmap_read(map, IMX7_OCOTP_ANA1, &val);
+	else
+		ret = regmap_read(map, IMX6_OCOTP_ANA1, &val);
+	if (ret) {
+		dev_err(&pdev->dev, "failed to read sensor data: %d\n", ret);
+		return ret;
+	}
+	ret = imx_init_calib(pdev, val);
+	if (ret)
+		return ret;
+
+	/* use OTP for thermal grade */
+	if (data->socdata->version == TEMPMON_IMX7)
+		ret = regmap_read(map, IMX7_OCOTP_TESTER3, &val);
+	else
+		ret = regmap_read(map, OCOTP_MEM0, &val);
+
+	if (ret) {
+		dev_err(&pdev->dev, "failed to read temp grade: %d\n", ret);
+		return ret;
+	}
+	imx_init_temp_grade(pdev, val);
+
+	return 0;
+}
+
+static int imx_init_from_nvmem_cells(struct platform_device *pdev)
+{
+	int ret;
+	u32 val;
+
+	ret = nvmem_cell_read_u32(&pdev->dev, "calib", &val);
+	if (ret < 0)
+		return ret;
+	imx_init_calib(pdev, val);
+
+	ret = nvmem_cell_read_u32(&pdev->dev, "temp_grade", &val);
+	if (ret < 0)
+		return ret;
+	imx_init_temp_grade(pdev, val);
 
 	return 0;
 }
@@ -783,10 +818,21 @@ static int imx_thermal_probe(struct platform_device *pdev)
 
 	platform_set_drvdata(pdev, data);
 
-	ret = imx_get_sensor_data(pdev);
-	if (ret) {
-		dev_err(&pdev->dev, "failed to get sensor data\n");
-		return ret;
+	if (of_find_property(pdev->dev.of_node, "nvmem-cells", NULL)) {
+		ret = imx_init_from_nvmem_cells(pdev);
+		if (ret == -EPROBE_DEFER)
+			return ret;
+		if (ret) {
+			dev_err(&pdev->dev, "failed to init from nvmem: %d\n",
+				ret);
+			return ret;
+		}
+	} else {
+		ret = imx_init_from_tempmon_data(pdev);
+		if (ret) {
+			dev_err(&pdev->dev, "failed to init from from fsl,tempmon-data\n");
+			return ret;
+		}
 	}
 
 	/*

--- a/drivers/thermal/imx_thermal.c
+++ b/drivers/thermal/imx_thermal.c
@@ -645,37 +645,46 @@ static void imx_init_temp_grade(struct platform_device *pdev, u32 val)
 static int imx_init_from_tempmon_data(struct platform_device *pdev)
 {
 	struct imx_thermal_data *data = platform_get_drvdata(pdev);
-	struct regmap *map;
+	struct device_node *np;
+	struct nvmem_device *nvdev;
 	int ret;
 	u32 val;
 
-	map = syscon_regmap_lookup_by_phandle(pdev->dev.of_node,
-					      "fsl,tempmon-data");
-	if (IS_ERR(map)) {
-		ret = PTR_ERR(map);
-		dev_err(&pdev->dev, "failed to get sensor regmap: %d\n", ret);
-		return ret;
+	np = of_parse_phandle(pdev->dev.of_node, "fsl,tempmon-data", 0);
+	if (!np) {
+		dev_err(&pdev->dev, "failed to get sensor device node\n");
+		return -ENOENT;
+	}
+
+	nvdev = of_nvmem_find(np);
+	of_node_put(np);
+	if (!nvdev) {
+		dev_err(&pdev->dev, "failed to get nvmem device\n");
+		return -ENOENT;
 	}
 
 	if (data->socdata->version == TEMPMON_IMX7)
-		ret = regmap_read(map, IMX7_OCOTP_ANA1, &val);
+		ret = nvmem_device_read(nvdev, IMX7_OCOTP_ANA1, 4, &val);
 	else
-		ret = regmap_read(map, IMX6_OCOTP_ANA1, &val);
-	if (ret) {
+		ret = nvmem_device_read(nvdev, IMX6_OCOTP_ANA1, 4, &val);
+	if (ret < 0) {
+		nvmem_device_put(nvdev);
 		dev_err(&pdev->dev, "failed to read sensor data: %d\n", ret);
 		return ret;
 	}
 	ret = imx_init_calib(pdev, val);
-	if (ret)
+	if (ret) {
+		nvmem_device_put(nvdev);
 		return ret;
+	}
 
 	/* use OTP for thermal grade */
 	if (data->socdata->version == TEMPMON_IMX7)
-		ret = regmap_read(map, IMX7_OCOTP_TESTER3, &val);
+		ret = nvmem_device_read(nvdev, IMX7_OCOTP_TESTER3, 4, &val);
 	else
-		ret = regmap_read(map, OCOTP_MEM0, &val);
-
-	if (ret) {
+		ret = nvmem_device_read(nvdev, OCOTP_MEM0, 4, &val);
+	nvmem_device_put(nvdev);
+	if (ret < 0) {
 		dev_err(&pdev->dev, "failed to read temp grade: %d\n", ret);
 		return ret;
 	}

--- a/include/linux/nvmem-consumer.h
+++ b/include/linux/nvmem-consumer.h
@@ -35,6 +35,7 @@ void nvmem_cell_put(struct nvmem_cell *cell);
 void devm_nvmem_cell_put(struct device *dev, struct nvmem_cell *cell);
 void *nvmem_cell_read(struct nvmem_cell *cell, size_t *len);
 int nvmem_cell_write(struct nvmem_cell *cell, void *buf, size_t len);
+int nvmem_cell_read_u32(struct device *dev, const char *cell_id, u32 *val);
 
 /* direct nvmem device read/write interface */
 struct nvmem_device *nvmem_device_get(struct device *dev, const char *name);
@@ -81,6 +82,12 @@ static inline void *nvmem_cell_read(struct nvmem_cell *cell, size_t *len)
 
 static inline int nvmem_cell_write(struct nvmem_cell *cell,
 				    const char *buf, size_t len)
+{
+	return -ENOSYS;
+}
+
+static inline int nvmem_cell_read_u32(struct device *dev,
+				      const char *cell_id, u32 *val)
 {
 	return -ENOSYS;
 }

--- a/include/linux/nvmem-consumer.h
+++ b/include/linux/nvmem-consumer.h
@@ -35,6 +35,7 @@ void nvmem_cell_put(struct nvmem_cell *cell);
 void devm_nvmem_cell_put(struct device *dev, struct nvmem_cell *cell);
 void *nvmem_cell_read(struct nvmem_cell *cell, size_t *len);
 int nvmem_cell_write(struct nvmem_cell *cell, void *buf, size_t len);
+int nvmem_cell_read_u16(struct device *dev, const char *cell_id, u16 *val);
 int nvmem_cell_read_u32(struct device *dev, const char *cell_id, u32 *val);
 
 /* direct nvmem device read/write interface */
@@ -84,6 +85,12 @@ static inline int nvmem_cell_write(struct nvmem_cell *cell,
 				    const char *buf, size_t len)
 {
 	return -ENOSYS;
+}
+
+static inline int nvmem_cell_read_u16(struct device *dev,
+				      const char *cell_id, u16 *val)
+{
+	return -EOPNOTSUPP;
 }
 
 static inline int nvmem_cell_read_u32(struct device *dev,

--- a/include/linux/nvmem-consumer.h
+++ b/include/linux/nvmem-consumer.h
@@ -52,6 +52,7 @@ ssize_t nvmem_device_cell_read(struct nvmem_device *nvmem,
 			   struct nvmem_cell_info *info, void *buf);
 int nvmem_device_cell_write(struct nvmem_device *nvmem,
 			    struct nvmem_cell_info *info, void *buf);
+struct nvmem_device *of_nvmem_find(struct device_node *nvmem_np);
 
 #else
 
@@ -146,6 +147,11 @@ static inline int nvmem_device_write(struct nvmem_device *nvmem,
 				     void *buf)
 {
 	return -ENOSYS;
+}
+
+static inline struct nvmem_device *of_nvmem_find(struct device_node *nvmem_np)
+{
+	return NULL;
 }
 #endif /* CONFIG_NVMEM */
 

--- a/scripts/dtc/dtc-lexer.l
+++ b/scripts/dtc/dtc-lexer.l
@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
https://github.com/atmark-techno/linux-4.14-at/pull/25 とだいたい同じです。

違いは：
＊scripts/dtc...YYLOC: 4.14アップストリームに入ってあるのでいらなかったけど、関係ない。gcc10だと必要なコミットです。
＊nvmemからいろいろバックポートする必要があった
＊imx-thermalのimx7対応がアップストリームされてないのでパッチ自体は少しでけ違います。
＊結局x1でnvmemのimx-ocotpは使っていないので、dtbをアップデートしなかった場合はただワーニングがでてimx-thermalはロードしない。普通に機動します。