### PR TITLE
ARM: imx: armadillo_iotg_addon: Fix Advaly SPICAN clock names

### DIFF
--- a/arch/arm/mach-imx/armadillo_iotg_addon/addon_advaly_spican_iotg_g3_intf1.dts
+++ b/arch/arm/mach-imx/armadillo_iotg_addon/addon_advaly_spican_iotg_g3_intf1.dts
@@ -37,11 +37,11 @@
 	fragment@1 {
 		target-path = "/";
 		__overlay__ {
-			clk20m: clk@1 {
+			clk20m1: dummy@1 {
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-frequency = <20000000>;
-				clock-output-names = "clk20m";
+				clock-output-names = "clk20m1";
 			};
 		};
 	};
@@ -60,7 +60,7 @@
 			can@0 {
 				compatible = "microchip,mcp2515";
 				reg = <0>;
-				clocks = <&clk20m>;
+				clocks = <&clk20m1>;
 				spi-max-frequency = <10000000>;
 				interrupt-parent = <&gpio5>;
 				interrupts = <12 IRQ_TYPE_EDGE_FALLING>;

--- a/arch/arm/mach-imx/armadillo_iotg_addon/addon_advaly_spican_iotg_g3_intf2.dts
+++ b/arch/arm/mach-imx/armadillo_iotg_addon/addon_advaly_spican_iotg_g3_intf2.dts
@@ -37,11 +37,11 @@
 	fragment@1 {
 		target-path = "/";
 		__overlay__ {
-			clk20m: clk@1 {
+			clk20m2: dummy@2 {
 				compatible = "fixed-clock";
 				#clock-cells = <0>;
 				clock-frequency = <20000000>;
-				clock-output-names = "clk20m";
+				clock-output-names = "clk20m2";
 			};
 		};
 	};
@@ -60,7 +60,7 @@
 			can@0 {
 				compatible = "microchip,mcp2515";
 				reg = <0>;
-				clocks = <&clk20m>;
+				clocks = <&clk20m2>;
 				spi-max-frequency = <10000000>;
 				interrupt-parent = <&gpio6>;
 				interrupts = <20 IRQ_TYPE_EDGE_FALLING>;


### PR DESCRIPTION
With the duplicated clock names, the driver fails to probe
if it uses SPICAN addons both on CON1 and CON2.

クロック名が重複しているため、CON1とCON2との両方で
アドバリーシステム製CANアドオンを使おうとすると、
CON1の片方しかprobeできませんでした。